### PR TITLE
TravisCI: Test PHP 7.2 and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
+  - nightly
   - hhvm
-  
+matrix:
+  allow_failures:
+    - php: nightly
+
 before_script:
   - composer install --no-interaction
 


### PR DESCRIPTION
Any plan on dropping PHP 5.x & HHVM support?